### PR TITLE
Added maxWidth property to Image

### DIFF
--- a/src/main/java/org/wickedsource/docxstamper/replace/typeresolver/image/Image.java
+++ b/src/main/java/org/wickedsource/docxstamper/replace/typeresolver/image/Image.java
@@ -14,14 +14,28 @@ public class Image {
 
     private String altText;
 
+    private Integer maxWidth;
+
     public Image(InputStream in) throws IOException {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         IOUtils.copy(in, out);
         this.imageBytes = out.toByteArray();
     }
 
+    public Image(InputStream in, Integer maxWidth) throws IOException {
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        IOUtils.copy(in, out);
+        this.imageBytes = out.toByteArray();
+        this.maxWidth = maxWidth;
+    }
+
     public Image(byte[] imageBytes) {
         this.imageBytes = imageBytes;
+    }
+
+    public Image(byte[] imageBytes, Integer maxWidth) {
+        this.imageBytes = imageBytes;
+        this.maxWidth = maxWidth;
     }
 
     public String getFilename() {
@@ -46,5 +60,13 @@ public class Image {
 
     public void setImageBytes(byte[] imageBytes) {
         this.imageBytes = imageBytes;
+    }
+
+    public Integer getMaxWidth() {
+        return maxWidth;
+    }
+
+    public void setMaxWidth(Integer maxWidth) {
+        this.maxWidth = maxWidth;
     }
 }

--- a/src/main/java/org/wickedsource/docxstamper/replace/typeresolver/image/Image.java
+++ b/src/main/java/org/wickedsource/docxstamper/replace/typeresolver/image/Image.java
@@ -6,6 +6,9 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 
+/**
+ * This class describes an image which will be inserted into document.
+ */
 public class Image {
 
     private byte[] imageBytes;
@@ -16,12 +19,19 @@ public class Image {
 
     private Integer maxWidth;
 
+    /**
+     * @param in - content of the image as InputStream
+     */
     public Image(InputStream in) throws IOException {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         IOUtils.copy(in, out);
         this.imageBytes = out.toByteArray();
     }
 
+    /**
+     * @param in - content of the image as InputStream
+     * @param maxWidth - max width of the image in twip
+     */
     public Image(InputStream in, Integer maxWidth) throws IOException {
         ByteArrayOutputStream out = new ByteArrayOutputStream();
         IOUtils.copy(in, out);
@@ -29,10 +39,17 @@ public class Image {
         this.maxWidth = maxWidth;
     }
 
+    /**
+     * @param imageBytes - content of the image as array of the bytes
+     */
     public Image(byte[] imageBytes) {
         this.imageBytes = imageBytes;
     }
 
+    /**
+     * @param imageBytes - content of the image as array of the bytes
+     * @param maxWidth - max width of the image in twip
+     */
     public Image(byte[] imageBytes, Integer maxWidth) {
         this.imageBytes = imageBytes;
         this.maxWidth = maxWidth;
@@ -62,11 +79,10 @@ public class Image {
         this.imageBytes = imageBytes;
     }
 
+    /**
+     * @return max width of the image in twip, if it is specified, or null.
+     */
     public Integer getMaxWidth() {
         return maxWidth;
-    }
-
-    public void setMaxWidth(Integer maxWidth) {
-        this.maxWidth = maxWidth;
     }
 }

--- a/src/main/java/org/wickedsource/docxstamper/replace/typeresolver/image/ImageResolver.java
+++ b/src/main/java/org/wickedsource/docxstamper/replace/typeresolver/image/ImageResolver.java
@@ -24,13 +24,13 @@ public class ImageResolver implements ITypeResolver {
             // TODO: adding the same image twice will put the image twice into the docx-zip file. make the second
             //       addition of the same image a reference instead.
             Image img = (Image) image;
-            return createRunWithImage(document, img.getImageBytes(), img.getFilename(), img.getAltText());
+            return createRunWithImage(document, img.getImageBytes(), img.getFilename(), img.getAltText(), img.getMaxWidth());
         } catch (Exception e) {
             throw new DocxStamperException("Error while adding image to document!", e);
         }
     }
 
-    public static R createRunWithImage(WordprocessingMLPackage wordMLPackage, byte[] bytes, String filenameHint, String altText) throws Exception {
+    public static R createRunWithImage(WordprocessingMLPackage wordMLPackage, byte[] bytes, String filenameHint, String altText, Integer maxWidth) throws Exception {
         BinaryPartAbstractImage imagePart = BinaryPartAbstractImage.createImagePart(wordMLPackage, bytes);
 
         // creating random ids assuming they are unique
@@ -44,8 +44,14 @@ public class ImageResolver implements ITypeResolver {
             altText = "dummyAltText";
         }
 
-        Inline inline = imagePart.createImageInline(filenameHint, altText,
-                id1, id2, false);
+        Inline inline;
+        if (maxWidth == null) {
+            inline = imagePart.createImageInline(filenameHint, altText,
+                    id1, id2, false);
+        } else {
+            inline = imagePart.createImageInline(filenameHint, altText,
+                    id1, id2, false, maxWidth);
+        }
 
         // Now add the inline in w:p/w:r/w:drawing
         org.docx4j.wml.ObjectFactory factory = new org.docx4j.wml.ObjectFactory();

--- a/src/test/java/org/wickedsource/docxstamper/ImageReplacementInGlobalParagraphsTest.java
+++ b/src/test/java/org/wickedsource/docxstamper/ImageReplacementInGlobalParagraphsTest.java
@@ -30,5 +30,17 @@ public class ImageReplacementInGlobalParagraphsTest extends AbstractDocx4jTest {
 
     }
 
+    @Test
+    public void testWithMaxWidth() throws Docx4JException, IOException {
+        Image monalisa = new Image(getClass().getResourceAsStream("monalisa.jpg"), 1000);
+        ImageContext context = new ImageContext();
+        context.setMonalisa(monalisa);
+
+        InputStream template = getClass().getResourceAsStream("ImageReplacementInGlobalParagraphsTest.docx");
+        WordprocessingMLPackage document = stampAndLoad(template, context);
+
+        Assert.assertTrue(((JAXBElement) ((R) ((P) document.getMainDocumentPart().getContent().get(2)).getContent().get(1)).getContent().get(0)).getValue() instanceof Drawing);
+        Assert.assertTrue(((JAXBElement) ((R) ((P) document.getMainDocumentPart().getContent().get(3)).getContent().get(1)).getContent().get(0)).getValue() instanceof Drawing);
+    }
 
 }


### PR DESCRIPTION
Hello! I use this library for inserting images (qr-codes), generated by third-party, into document. And I was a bit frustrated that I can't affect on image size in document. 
Since version 3.3.0 _docx4j_ library provides method
`createImageInline(String filenameHint, String altText, int id1, int id2, boolean link, int maxWidth)`
From the official documentation: this parameter is 
> Useful if the image is to be inserted into a table cell of known width.

So I added maxWidth property into _Image_ object and wrote a code which handle it in _ImageResolver_.
My changes have no side effects, so people can use Image class as they did before. 