### PR TITLE
Fix paragraph deletion index shifts after repeatDocPart

### DIFF
--- a/src/main/java/org/wickedsource/docxstamper/util/ObjectDeleter.java
+++ b/src/main/java/org/wickedsource/docxstamper/util/ObjectDeleter.java
@@ -27,6 +27,17 @@ public class ObjectDeleter {
         if (paragraphCoordinates.getParentTableCellCoordinates() == null) {
             // global paragraph
             int indexToDelete = paragraphCoordinates.getIndex() - objectsDeletedFromMainDocument;
+
+            // detect repeatDocPart error
+            if (document.getMainDocumentPart().getContent().get(indexToDelete) != paragraphCoordinates.getParagraph()) {
+              var index = document.getMainDocumentPart().getContent().indexOf(paragraphCoordinates.getParagraph());
+              if (index < 0) {
+                return;
+              }
+              objectsDeletedFromMainDocument = paragraphCoordinates.getIndex() - index;
+              indexToDelete = paragraphCoordinates.getIndex() - objectsDeletedFromMainDocument;
+            }
+
             document.getMainDocumentPart().getContent().remove(indexToDelete);
             objectsDeletedFromMainDocument++;
         } else {


### PR DESCRIPTION
It's a monkey-patch for `ObjectDeleter.deleteParagraph()` which fixes index shifts after `repeatDocPart` processor.