### PR TITLE
Add configured expression resolver to default comment proccessors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,6 @@ settings.xml
 /.DS_Store
 /.project
 /.gradle/
+/bin/
+/build/
+/.settings/

--- a/src/main/java/org/wickedsource/docxstamper/DocxStamper.java
+++ b/src/main/java/org/wickedsource/docxstamper/DocxStamper.java
@@ -1,5 +1,10 @@
 package org.wickedsource.docxstamper;
 
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Date;
+import java.util.Map;
+
 import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
 import org.wickedsource.docxstamper.api.DocxStamperException;
 import org.wickedsource.docxstamper.api.commentprocessor.ICommentProcessor;
@@ -9,7 +14,12 @@ import org.wickedsource.docxstamper.el.ExpressionResolver;
 import org.wickedsource.docxstamper.processor.CommentProcessorRegistry;
 import org.wickedsource.docxstamper.processor.displayif.DisplayIfProcessor;
 import org.wickedsource.docxstamper.processor.displayif.IDisplayIfProcessor;
-import org.wickedsource.docxstamper.processor.repeat.*;
+import org.wickedsource.docxstamper.processor.repeat.IParagraphRepeatProcessor;
+import org.wickedsource.docxstamper.processor.repeat.IRepeatDocPartProcessor;
+import org.wickedsource.docxstamper.processor.repeat.IRepeatProcessor;
+import org.wickedsource.docxstamper.processor.repeat.ParagraphRepeatProcessor;
+import org.wickedsource.docxstamper.processor.repeat.RepeatDocPartProcessor;
+import org.wickedsource.docxstamper.processor.repeat.RepeatProcessor;
 import org.wickedsource.docxstamper.processor.replaceExpression.IReplaceWithProcessor;
 import org.wickedsource.docxstamper.processor.replaceExpression.ReplaceWithProcessor;
 import org.wickedsource.docxstamper.proxy.ProxyBuilder;
@@ -18,11 +28,6 @@ import org.wickedsource.docxstamper.replace.typeresolver.DateResolver;
 import org.wickedsource.docxstamper.replace.typeresolver.FallbackResolver;
 import org.wickedsource.docxstamper.replace.typeresolver.image.Image;
 import org.wickedsource.docxstamper.replace.typeresolver.image.ImageResolver;
-
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.util.Date;
-import java.util.Map;
 
 /**
  * <p>
@@ -69,8 +74,8 @@ public class DocxStamper<T> {
     commentProcessorRegistry.setExpressionResolver(expressionResolver);
     commentProcessorRegistry.setFailOnInvalidExpression(config.isFailOnUnresolvedExpression());
     commentProcessorRegistry.registerCommentProcessor(IRepeatProcessor.class, new RepeatProcessor(typeResolverRegistry, expressionResolver));
-    commentProcessorRegistry.registerCommentProcessor(IParagraphRepeatProcessor.class, new ParagraphRepeatProcessor(typeResolverRegistry));
-    commentProcessorRegistry.registerCommentProcessor(IRepeatDocPartProcessor.class, new RepeatDocPartProcessor(typeResolverRegistry));
+    commentProcessorRegistry.registerCommentProcessor(IParagraphRepeatProcessor.class, new ParagraphRepeatProcessor(typeResolverRegistry, expressionResolver));
+    commentProcessorRegistry.registerCommentProcessor(IRepeatDocPartProcessor.class, new RepeatDocPartProcessor(typeResolverRegistry, expressionResolver));
     commentProcessorRegistry.registerCommentProcessor(IDisplayIfProcessor.class, new DisplayIfProcessor());
     commentProcessorRegistry.registerCommentProcessor(IReplaceWithProcessor.class,
             new ReplaceWithProcessor());

--- a/src/main/java/org/wickedsource/docxstamper/processor/repeat/ParagraphRepeatProcessor.java
+++ b/src/main/java/org/wickedsource/docxstamper/processor/repeat/ParagraphRepeatProcessor.java
@@ -8,6 +8,7 @@ import org.docx4j.wml.ContentAccessor;
 import org.docx4j.wml.P;
 import org.wickedsource.docxstamper.api.coordinates.ParagraphCoordinates;
 import org.wickedsource.docxstamper.api.typeresolver.TypeResolverRegistry;
+import org.wickedsource.docxstamper.el.ExpressionResolver;
 import org.wickedsource.docxstamper.processor.BaseCommentProcessor;
 import org.wickedsource.docxstamper.replace.PlaceholderReplacer;
 import org.wickedsource.docxstamper.util.CommentUtil;
@@ -29,8 +30,9 @@ public class ParagraphRepeatProcessor extends BaseCommentProcessor implements IP
 
     private PlaceholderReplacer<Object> placeholderReplacer;
 
-    public ParagraphRepeatProcessor(TypeResolverRegistry typeResolverRegistry) {
+    public ParagraphRepeatProcessor(TypeResolverRegistry typeResolverRegistry, ExpressionResolver expressionResolver) {
         this.placeholderReplacer = new PlaceholderReplacer<>(typeResolverRegistry);
+        this.placeholderReplacer.setExpressionResolver(expressionResolver);
     }
 
     @Override

--- a/src/main/java/org/wickedsource/docxstamper/processor/repeat/RepeatDocPartProcessor.java
+++ b/src/main/java/org/wickedsource/docxstamper/processor/repeat/RepeatDocPartProcessor.java
@@ -5,6 +5,7 @@ import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
 import org.docx4j.wml.*;
 import org.jvnet.jaxb2_commons.ppp.Child;
 import org.wickedsource.docxstamper.api.typeresolver.TypeResolverRegistry;
+import org.wickedsource.docxstamper.el.ExpressionResolver;
 import org.wickedsource.docxstamper.processor.BaseCommentProcessor;
 import org.wickedsource.docxstamper.replace.PlaceholderReplacer;
 import org.wickedsource.docxstamper.util.CommentUtil;
@@ -22,8 +23,9 @@ public class RepeatDocPartProcessor extends BaseCommentProcessor implements IRep
     private Map<CommentWrapper, List<Object>> partsToRepeat = new HashMap<>();
     private PlaceholderReplacer<Object> placeholderReplacer;
 
-    public RepeatDocPartProcessor(TypeResolverRegistry typeResolverRegistry) {
+    public RepeatDocPartProcessor(TypeResolverRegistry typeResolverRegistry, ExpressionResolver expressionResolver) {
         this.placeholderReplacer = new PlaceholderReplacer<>(typeResolverRegistry);
+        this.placeholderReplacer.setExpressionResolver(expressionResolver);
     }
 
     @Override

--- a/src/main/java/org/wickedsource/docxstamper/util/IndexedRun.java
+++ b/src/main/java/org/wickedsource/docxstamper/util/IndexedRun.java
@@ -1,4 +1,4 @@
-package org.wickedsource.docxstamper.replace;
+package org.wickedsource.docxstamper.util;
 
 import org.docx4j.wml.R;
 import org.wickedsource.docxstamper.util.RunUtil;

--- a/src/main/java/org/wickedsource/docxstamper/util/ParagraphWrapper.java
+++ b/src/main/java/org/wickedsource/docxstamper/util/ParagraphWrapper.java
@@ -1,12 +1,10 @@
 package org.wickedsource.docxstamper.util;
 
-import org.docx4j.wml.P;
-import org.docx4j.wml.R;
-import org.wickedsource.docxstamper.replace.IndexedRun;
-import org.wickedsource.docxstamper.util.RunUtil;
-
 import java.util.ArrayList;
 import java.util.List;
+
+import org.docx4j.wml.P;
+import org.docx4j.wml.R;
 
 /**
  * A "Run" defines a region of text within a docx document with a common set of properties. Word processors are

--- a/src/test/java/org/wickedsource/docxstamper/AbstractDocx4jTest.java
+++ b/src/test/java/org/wickedsource/docxstamper/AbstractDocx4jTest.java
@@ -1,11 +1,19 @@
 package org.wickedsource.docxstamper;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+
 import org.docx4j.openpackaging.exceptions.Docx4JException;
 import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.*;
 
 /**
  * Common methods to interact with docx documents.

--- a/src/test/java/org/wickedsource/docxstamper/replace/IndexedRunTest.java
+++ b/src/test/java/org/wickedsource/docxstamper/replace/IndexedRunTest.java
@@ -5,6 +5,7 @@ import org.docx4j.wml.ObjectFactory;
 import org.docx4j.wml.R;
 import org.junit.Assert;
 import org.junit.Test;
+import org.wickedsource.docxstamper.util.IndexedRun;
 import org.wickedsource.docxstamper.util.RunUtil;
 
 public class IndexedRunTest {


### PR DESCRIPTION
This version registers configured expression resolver to `ParagraphRepeatProcessor` and `RepeatDocPartProcessor`
which before defaulted to `NoOpEvaluationContextConfigurer`.
