### PR TITLE
Fix/excluded last placeholder

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>linkyard</groupId>
+    <groupId>pro.verron</groupId>
     <artifactId>docx-stamper</artifactId>
     <version>1.4.1-SNAPSHOT</version>
     <packaging>jar</packaging>
@@ -30,6 +30,16 @@
     </licenses>
 
     <developers>
+        <developer>
+            <email>ynaciri@gmail.com</email>
+            <name>Youssouf Naciri</name>
+            <url>https://youssouf.naciri.fr</url>
+        </developer>
+        <developer>
+            <email>joseph@verron.pro</email>
+            <name>Joseph Verron</name>
+            <url>https://verron.pro</url>
+        </developer>
         <developer>
             <email>tom.hombergs@gmail.com</email>
             <name>Tom Hombergs</name>

--- a/pom.xml
+++ b/pom.xml
@@ -1,0 +1,114 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <groupId>linkyard</groupId>
+    <artifactId>docx-stamper</artifactId>
+    <version>1.4.1-SNAPSHOT</version>
+    <packaging>jar</packaging>
+    <name>docx-stamper</name>
+    <properties>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>1.8</maven.compiler.source>
+    </properties>
+    <description>Docx-stamper is a Java template engine for docx documents. This is a maintenance fork from
+        https://github.com/thombergs/docx-stamper.
+    </description>
+    <url>https://github.com/bflorat/docx-stamper</url>
+    <scm>
+        <url>https://github.com/bflorat/docx-stamper</url>
+        <developerConnection>scm:git:https://github.com/bflorat/docx-stamper.git</developerConnection>
+        <connection>https://github.com/bflorat/docx-stamper.git</connection>
+    </scm>
+
+    <licenses>
+        <license>
+            <name>MIT License</name>
+            <url>http://opensource.org/licenses/MIT</url>
+        </license>
+    </licenses>
+
+    <developers>
+        <developer>
+            <email>tom.hombergs@gmail.com</email>
+            <name>Tom Hombergs</name>
+            <url>http://wickedsource.org</url>
+        </developer>
+        <developer>
+            <email>bertrand@florat.net</email>
+            <name>Bertrand Florat</name>
+            <url>https://florat.net</url>
+        </developer>
+    </developers>
+    <build>
+        <plugins>
+            <plugin>
+                <artifactId>maven-source-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>attach-sources</id>
+                        <goals>
+                            <goal>jar</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+   
+    <dependencies>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+            <version>2.5</version>
+        </dependency>
+        <dependency>
+            <groupId>org.javassist</groupId>
+            <artifactId>javassist</artifactId>
+            <version>3.21.0-GA</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.4</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-expression</artifactId>
+            <version>4.3.6.RELEASE</version>
+        </dependency>
+
+
+        <!-- For unknown reason, we need this deps to avoid "docx4j Couldn't get [Content_Types].xml from ZipFile" errors
+         See https://stackoverflow.com/questions/31093454/docx4j-couldnt-get-content-types-xml-from-zipfile -->
+        <dependency>
+            <groupId>org.docx4j</groupId>
+            <artifactId>docx4j-JAXB-MOXy</artifactId>
+            <version>11.2.9</version>
+        </dependency>
+
+        <!-- Required when running with a recent JRE as jaxb has been dropped from Java 9 -->
+        <dependency>
+            <groupId>jakarta.xml.bind</groupId>
+            <artifactId>jakarta.xml.bind-api</artifactId>
+            <version>2.3.2</version>
+            <scope>compile</scope>
+        </dependency>
+    </dependencies>
+
+    <distributionManagement>
+        <snapshotRepository>
+            <id>ossrh</id>
+            <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+        </snapshotRepository>
+        <repository>
+            <id>ossrh</id>
+            <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+        </repository>
+    </distributionManagement>
+
+
+</project>
+

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>pro.verron</groupId>
     <artifactId>docx-stamper</artifactId>
-    <version>1.4.1-SNAPSHOT</version>
+    <version>1.4.2-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>docx-stamper</name>
     <properties>

--- a/src/main/java/org/wickedsource/docxstamper/DocxStamper.java
+++ b/src/main/java/org/wickedsource/docxstamper/DocxStamper.java
@@ -69,8 +69,8 @@ public class DocxStamper<T> {
     commentProcessorRegistry.setExpressionResolver(expressionResolver);
     commentProcessorRegistry.setFailOnInvalidExpression(config.isFailOnUnresolvedExpression());
     commentProcessorRegistry.registerCommentProcessor(IRepeatProcessor.class, new RepeatProcessor(typeResolverRegistry, expressionResolver));
-    commentProcessorRegistry.registerCommentProcessor(IParagraphRepeatProcessor.class, new ParagraphRepeatProcessor(typeResolverRegistry));
-    commentProcessorRegistry.registerCommentProcessor(IRepeatDocPartProcessor.class, new RepeatDocPartProcessor(typeResolverRegistry));
+    commentProcessorRegistry.registerCommentProcessor(IParagraphRepeatProcessor.class, new ParagraphRepeatProcessor(typeResolverRegistry, expressionResolver));
+    commentProcessorRegistry.registerCommentProcessor(IRepeatDocPartProcessor.class, new RepeatDocPartProcessor(typeResolverRegistry, expressionResolver));
     commentProcessorRegistry.registerCommentProcessor(IDisplayIfProcessor.class, new DisplayIfProcessor());
     commentProcessorRegistry.registerCommentProcessor(IReplaceWithProcessor.class,
             new ReplaceWithProcessor());

--- a/src/main/java/org/wickedsource/docxstamper/DocxStamper.java
+++ b/src/main/java/org/wickedsource/docxstamper/DocxStamper.java
@@ -34,138 +34,138 @@ import java.util.Map;
  */
 public class DocxStamper<T> {
 
-  private PlaceholderReplacer<T> placeholderReplacer;
+    private PlaceholderReplacer<T> placeholderReplacer;
 
-  private CommentProcessorRegistry commentProcessorRegistry;
+    private CommentProcessorRegistry commentProcessorRegistry;
 
-  private TypeResolverRegistry typeResolverRegistry;
+    private TypeResolverRegistry typeResolverRegistry;
 
-  private DocxStamperConfiguration config = new DocxStamperConfiguration();
+    private DocxStamperConfiguration config = new DocxStamperConfiguration();
 
-  public DocxStamper() {
-    initFields();
-  }
-
-  public DocxStamper(DocxStamperConfiguration config) {
-    this.config = config;
-    initFields();
-  }
-
-  private void initFields() {
-    typeResolverRegistry = new TypeResolverRegistry(new FallbackResolver());
-    typeResolverRegistry.registerTypeResolver(Image.class, new ImageResolver());
-    typeResolverRegistry.registerTypeResolver(Date.class, new DateResolver("dd.MM.yyyy"));
-    for (Map.Entry<Class<?>, ITypeResolver> entry : config.getTypeResolvers().entrySet()) {
-      typeResolverRegistry.registerTypeResolver(entry.getKey(), entry.getValue());
+    public DocxStamper() {
+        initFields();
     }
 
-    ExpressionResolver expressionResolver = new ExpressionResolver(config.getEvaluationContextConfigurer());
-    placeholderReplacer = new PlaceholderReplacer<>(typeResolverRegistry, config.getLineBreakPlaceholder());
-    placeholderReplacer.setExpressionResolver(expressionResolver);
-    placeholderReplacer.setLeaveEmptyOnExpressionError(config.isLeaveEmptyOnExpressionError());
-    placeholderReplacer.setReplaceNullValues(config.isReplaceNullValues());
-
-    commentProcessorRegistry = new CommentProcessorRegistry(placeholderReplacer);
-    commentProcessorRegistry.setExpressionResolver(expressionResolver);
-    commentProcessorRegistry.setFailOnInvalidExpression(config.isFailOnUnresolvedExpression());
-    commentProcessorRegistry.registerCommentProcessor(IRepeatProcessor.class, new RepeatProcessor(typeResolverRegistry, expressionResolver));
-    commentProcessorRegistry.registerCommentProcessor(IParagraphRepeatProcessor.class, new ParagraphRepeatProcessor(typeResolverRegistry, expressionResolver));
-    commentProcessorRegistry.registerCommentProcessor(IRepeatDocPartProcessor.class, new RepeatDocPartProcessor(typeResolverRegistry, expressionResolver));
-    commentProcessorRegistry.registerCommentProcessor(IDisplayIfProcessor.class, new DisplayIfProcessor());
-    commentProcessorRegistry.registerCommentProcessor(IReplaceWithProcessor.class,
-            new ReplaceWithProcessor());
-    for (Map.Entry<Class<?>, ICommentProcessor> entry : config.getCommentProcessors().entrySet()) {
-      commentProcessorRegistry.registerCommentProcessor(entry.getKey(), entry.getValue());
+    public DocxStamper(DocxStamperConfiguration config) {
+        this.config = config;
+        initFields();
     }
-  }
 
-  /**
-   * <p>
-   * Reads in a .docx template and "stamps" it into the given OutputStream, using the specified context object to
-   * fill out any expressions it finds.
-   * </p>
-   * <p>
-   * In the .docx template you have the following options to influence the "stamping" process:
-   * </p>
-   * <ul>
-   * <li>Use expressions like ${name} or ${person.isOlderThan(18)} in the template's text. These expressions are resolved
-   * against the contextRoot object you pass into this method and are replaced by the results.</li>
-   * <li>Use comments within the .docx template to mark certain paragraphs to be manipulated. </li>
-   * </ul>
-   * <p>
-   * Within comments, you can put expressions in which you can use the following methods by default:
-   * </p>
-   * <ul>
-   * <li><em>displayParagraphIf(boolean)</em> to conditionally display paragraphs or not</li>
-   * <li><em>displayTableRowIf(boolean)</em> to conditionally display table rows or not</li>
-   * <li><em>displayTableIf(boolean)</em> to conditionally display whole tables or not</li>
-   * <li><em>repeatTableRow(List&lt;Object&gt;)</em> to create a new table row for each object in the list and resolve expressions
-   * within the table cells against one of the objects within the list.</li>
-   * </ul>
-   * <p>
-   * If you need a wider vocabulary of methods available in the comments, you can create your own ICommentProcessor
-   * and register it via getCommentProcessorRegistry().addCommentProcessor().
-   * </p>
-   *
-   * @param template    the .docx template.
-   * @param contextRoot the context root object against which all expressions found in the template are evaluated.
-   * @param out         the output stream in which to write the resulting .docx document.
-   * @throws DocxStamperException in case of an error.
-   */
-  public void stamp(InputStream template, T contextRoot, OutputStream out) throws DocxStamperException {
-    try {
-      WordprocessingMLPackage document = WordprocessingMLPackage.load(template);
-      stamp(document, contextRoot, out);
-    } catch (DocxStamperException e) {
-      throw e;
-    } catch (Exception e) {
-      throw new DocxStamperException(e);
+    private void initFields() {
+        typeResolverRegistry = new TypeResolverRegistry(new FallbackResolver());
+        typeResolverRegistry.registerTypeResolver(Image.class, new ImageResolver());
+        typeResolverRegistry.registerTypeResolver(Date.class, new DateResolver("dd.MM.yyyy"));
+        for (Map.Entry<Class<?>, ITypeResolver> entry : config.getTypeResolvers().entrySet()) {
+            typeResolverRegistry.registerTypeResolver(entry.getKey(), entry.getValue());
+        }
+
+        ExpressionResolver expressionResolver = new ExpressionResolver(config.getEvaluationContextConfigurer());
+        placeholderReplacer = new PlaceholderReplacer<>(typeResolverRegistry, config.getLineBreakPlaceholder());
+        placeholderReplacer.setExpressionResolver(expressionResolver);
+        placeholderReplacer.setLeaveEmptyOnExpressionError(config.isLeaveEmptyOnExpressionError());
+        placeholderReplacer.setReplaceNullValues(config.isReplaceNullValues());
+
+        commentProcessorRegistry = new CommentProcessorRegistry(placeholderReplacer);
+        commentProcessorRegistry.setExpressionResolver(expressionResolver);
+        commentProcessorRegistry.setFailOnInvalidExpression(config.isFailOnUnresolvedExpression());
+        commentProcessorRegistry.registerCommentProcessor(IRepeatProcessor.class, new RepeatProcessor(typeResolverRegistry, expressionResolver));
+        commentProcessorRegistry.registerCommentProcessor(IParagraphRepeatProcessor.class, new ParagraphRepeatProcessor(typeResolverRegistry, expressionResolver));
+        commentProcessorRegistry.registerCommentProcessor(IRepeatDocPartProcessor.class, new RepeatDocPartProcessor(typeResolverRegistry, expressionResolver, config));
+        commentProcessorRegistry.registerCommentProcessor(IDisplayIfProcessor.class, new DisplayIfProcessor());
+        commentProcessorRegistry.registerCommentProcessor(IReplaceWithProcessor.class,
+                new ReplaceWithProcessor());
+        for (Map.Entry<Class<?>, ICommentProcessor> entry : config.getCommentProcessors().entrySet()) {
+            commentProcessorRegistry.registerCommentProcessor(entry.getKey(), entry.getValue());
+        }
     }
-  }
 
-  /**
-   * Same as stamp(InputStream, T, OutputStream) except that you may pass in a DOCX4J document as a template instead
-   * of an InputStream.
-   *
-   * @param document    the .docx template.
-   * @param contextRoot the context root object against which all expressions found in the template are evaluated.
-   * @param out         the output stream in which to write the resulting .docx document.
-   * @throws DocxStamperException in case of an error.
-   */
-  public void stamp(WordprocessingMLPackage document, T contextRoot, OutputStream out) throws DocxStamperException {
-    try {
-      ProxyBuilder<T> proxyBuilder = addCustomInterfacesToContextRoot(contextRoot, this.config.getExpressionFunctions());
-      processComments(document, proxyBuilder);
-      replaceExpressions(document, proxyBuilder);
-      document.save(out);
-      commentProcessorRegistry.reset();
-    } catch (DocxStamperException e) {
-      throw e;
-    } catch (Exception e) {
-      throw new DocxStamperException(e);
+    /**
+     * <p>
+     * Reads in a .docx template and "stamps" it into the given OutputStream, using the specified context object to
+     * fill out any expressions it finds.
+     * </p>
+     * <p>
+     * In the .docx template you have the following options to influence the "stamping" process:
+     * </p>
+     * <ul>
+     * <li>Use expressions like ${name} or ${person.isOlderThan(18)} in the template's text. These expressions are resolved
+     * against the contextRoot object you pass into this method and are replaced by the results.</li>
+     * <li>Use comments within the .docx template to mark certain paragraphs to be manipulated. </li>
+     * </ul>
+     * <p>
+     * Within comments, you can put expressions in which you can use the following methods by default:
+     * </p>
+     * <ul>
+     * <li><em>displayParagraphIf(boolean)</em> to conditionally display paragraphs or not</li>
+     * <li><em>displayTableRowIf(boolean)</em> to conditionally display table rows or not</li>
+     * <li><em>displayTableIf(boolean)</em> to conditionally display whole tables or not</li>
+     * <li><em>repeatTableRow(List&lt;Object&gt;)</em> to create a new table row for each object in the list and resolve expressions
+     * within the table cells against one of the objects within the list.</li>
+     * </ul>
+     * <p>
+     * If you need a wider vocabulary of methods available in the comments, you can create your own ICommentProcessor
+     * and register it via getCommentProcessorRegistry().addCommentProcessor().
+     * </p>
+     *
+     * @param template    the .docx template.
+     * @param contextRoot the context root object against which all expressions found in the template are evaluated.
+     * @param out         the output stream in which to write the resulting .docx document.
+     * @throws DocxStamperException in case of an error.
+     */
+    public void stamp(InputStream template, T contextRoot, OutputStream out) throws DocxStamperException {
+        try {
+            WordprocessingMLPackage document = WordprocessingMLPackage.load(template);
+            stamp(document, contextRoot, out);
+        } catch (DocxStamperException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new DocxStamperException(e);
+        }
     }
-  }
 
-  private ProxyBuilder<T> addCustomInterfacesToContextRoot(T contextRoot, Map<Class<?>, Object> interfacesToImplementations) {
-    ProxyBuilder<T> proxyBuilder = new ProxyBuilder<T>()
-            .withRoot(contextRoot);
-    if (interfacesToImplementations.isEmpty()) {
-      return proxyBuilder;
+    /**
+     * Same as stamp(InputStream, T, OutputStream) except that you may pass in a DOCX4J document as a template instead
+     * of an InputStream.
+     *
+     * @param document    the .docx template.
+     * @param contextRoot the context root object against which all expressions found in the template are evaluated.
+     * @param out         the output stream in which to write the resulting .docx document.
+     * @throws DocxStamperException in case of an error.
+     */
+    public void stamp(WordprocessingMLPackage document, T contextRoot, OutputStream out) throws DocxStamperException {
+        try {
+            ProxyBuilder<T> proxyBuilder = addCustomInterfacesToContextRoot(contextRoot, this.config.getExpressionFunctions());
+            processComments(document, proxyBuilder);
+            replaceExpressions(document, proxyBuilder);
+            document.save(out);
+            commentProcessorRegistry.reset();
+        } catch (DocxStamperException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new DocxStamperException(e);
+        }
     }
-    for (Map.Entry<Class<?>, Object> entry : interfacesToImplementations.entrySet()) {
-      Class<?> interfaceClass = entry.getKey();
-      Object implementation = entry.getValue();
-      proxyBuilder.withInterface(interfaceClass, implementation);
+
+    private ProxyBuilder<T> addCustomInterfacesToContextRoot(T contextRoot, Map<Class<?>, Object> interfacesToImplementations) {
+        ProxyBuilder<T> proxyBuilder = new ProxyBuilder<T>()
+                .withRoot(contextRoot);
+        if (interfacesToImplementations.isEmpty()) {
+            return proxyBuilder;
+        }
+        for (Map.Entry<Class<?>, Object> entry : interfacesToImplementations.entrySet()) {
+            Class<?> interfaceClass = entry.getKey();
+            Object implementation = entry.getValue();
+            proxyBuilder.withInterface(interfaceClass, implementation);
+        }
+        return proxyBuilder;
     }
-    return proxyBuilder;
-  }
 
-  private void replaceExpressions(WordprocessingMLPackage document, ProxyBuilder<T> proxyBuilder) {
-    placeholderReplacer.resolveExpressions(document, proxyBuilder);
-  }
+    private void replaceExpressions(WordprocessingMLPackage document, ProxyBuilder<T> proxyBuilder) {
+        placeholderReplacer.resolveExpressions(document, proxyBuilder);
+    }
 
-  private void processComments(final WordprocessingMLPackage document, ProxyBuilder<T> proxyBuilder) {
-    commentProcessorRegistry.runProcessors(document, proxyBuilder);
-  }
+    private void processComments(final WordprocessingMLPackage document, ProxyBuilder<T> proxyBuilder) {
+        commentProcessorRegistry.runProcessors(document, proxyBuilder);
+    }
 
 }

--- a/src/main/java/org/wickedsource/docxstamper/DocxStamper.java
+++ b/src/main/java/org/wickedsource/docxstamper/DocxStamper.java
@@ -70,7 +70,7 @@ public class DocxStamper<T> {
         commentProcessorRegistry.setFailOnInvalidExpression(config.isFailOnUnresolvedExpression());
         commentProcessorRegistry.registerCommentProcessor(IRepeatProcessor.class, new RepeatProcessor(typeResolverRegistry, expressionResolver));
         commentProcessorRegistry.registerCommentProcessor(IParagraphRepeatProcessor.class, new ParagraphRepeatProcessor(typeResolverRegistry, expressionResolver));
-        commentProcessorRegistry.registerCommentProcessor(IRepeatDocPartProcessor.class, new RepeatDocPartProcessor(typeResolverRegistry, expressionResolver, config));
+        commentProcessorRegistry.registerCommentProcessor(IRepeatDocPartProcessor.class, new RepeatDocPartProcessor(config));
         commentProcessorRegistry.registerCommentProcessor(IDisplayIfProcessor.class, new DisplayIfProcessor());
         commentProcessorRegistry.registerCommentProcessor(IReplaceWithProcessor.class,
                 new ReplaceWithProcessor());

--- a/src/main/java/org/wickedsource/docxstamper/processor/repeat/ParagraphRepeatProcessor.java
+++ b/src/main/java/org/wickedsource/docxstamper/processor/repeat/ParagraphRepeatProcessor.java
@@ -8,6 +8,7 @@ import org.docx4j.wml.ContentAccessor;
 import org.docx4j.wml.P;
 import org.wickedsource.docxstamper.api.coordinates.ParagraphCoordinates;
 import org.wickedsource.docxstamper.api.typeresolver.TypeResolverRegistry;
+import org.wickedsource.docxstamper.el.ExpressionResolver;
 import org.wickedsource.docxstamper.processor.BaseCommentProcessor;
 import org.wickedsource.docxstamper.replace.PlaceholderReplacer;
 import org.wickedsource.docxstamper.util.CommentUtil;
@@ -29,8 +30,9 @@ public class ParagraphRepeatProcessor extends BaseCommentProcessor implements IP
 
     private PlaceholderReplacer<Object> placeholderReplacer;
 
-    public ParagraphRepeatProcessor(TypeResolverRegistry typeResolverRegistry) {
+    public ParagraphRepeatProcessor(TypeResolverRegistry typeResolverRegistry, ExpressionResolver expressionResolver) {
         this.placeholderReplacer = new PlaceholderReplacer<>(typeResolverRegistry);
+        this.placeholderReplacer.setExpressionResolver(expressionResolver);
     }
 
     @Override

--- a/src/main/java/org/wickedsource/docxstamper/processor/repeat/RepeatDocPartProcessor.java
+++ b/src/main/java/org/wickedsource/docxstamper/processor/repeat/RepeatDocPartProcessor.java
@@ -132,10 +132,10 @@ public class RepeatDocPartProcessor extends BaseCommentProcessor implements IRep
                 startFound = true;
             }
             if (startFound) {
+                repeatElements.add(element);
                 if (depthElementSearch(commentWrapper.getCommentRangeEnd(), element)) {
                     break;
                 }
-                repeatElements.add(element);
             }
         }
         return repeatElements;

--- a/src/main/java/org/wickedsource/docxstamper/processor/repeat/RepeatDocPartProcessor.java
+++ b/src/main/java/org/wickedsource/docxstamper/processor/repeat/RepeatDocPartProcessor.java
@@ -5,6 +5,7 @@ import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
 import org.docx4j.wml.*;
 import org.jvnet.jaxb2_commons.ppp.Child;
 import org.wickedsource.docxstamper.api.typeresolver.TypeResolverRegistry;
+import org.wickedsource.docxstamper.el.ExpressionResolver;
 import org.wickedsource.docxstamper.processor.BaseCommentProcessor;
 import org.wickedsource.docxstamper.replace.PlaceholderReplacer;
 import org.wickedsource.docxstamper.util.CommentUtil;
@@ -22,8 +23,9 @@ public class RepeatDocPartProcessor extends BaseCommentProcessor implements IRep
     private Map<CommentWrapper, List<Object>> partsToRepeat = new HashMap<>();
     private PlaceholderReplacer<Object> placeholderReplacer;
 
-    public RepeatDocPartProcessor(TypeResolverRegistry typeResolverRegistry) {
+    public RepeatDocPartProcessor(TypeResolverRegistry typeResolverRegistry, ExpressionResolver expressionResolver) {
         this.placeholderReplacer = new PlaceholderReplacer<>(typeResolverRegistry);
+        this.placeholderReplacer.setExpressionResolver(expressionResolver);
     }
 
     @Override

--- a/src/main/java/org/wickedsource/docxstamper/processor/repeat/RepeatDocPartProcessor.java
+++ b/src/main/java/org/wickedsource/docxstamper/processor/repeat/RepeatDocPartProcessor.java
@@ -60,13 +60,24 @@ public class RepeatDocPartProcessor extends BaseCommentProcessor implements IRep
         subTemplates.put(currentCommentWrapper, extractSubTemplate(currentCommentWrapper, repeatElements));
     }
 
+    private WordprocessingMLPackage copyTemplate(WordprocessingMLPackage doc) {
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            doc.save(baos);
+            return WordprocessingMLPackage.load(new ByteArrayInputStream(baos.toByteArray()));
+        } catch (Exception e) {
+            System.out.println(e);
+            return null;
+        }
+    }
+
     @Override
     public void commitChanges(WordprocessingMLPackage document) {
         int count = 0;
 
         for (CommentWrapper commentWrapper : subContexts.keySet()) {
             List<Object> expressionContexts = subContexts.get(commentWrapper);
-            WordprocessingMLPackage subTemplate = subTemplates.get(commentWrapper);
+            WordprocessingMLPackage subTemplate = copyTemplate(subTemplates.get(commentWrapper));
 
             List<Object> changes = new ArrayList<>();
 

--- a/src/main/java/org/wickedsource/docxstamper/processor/repeat/RepeatDocPartProcessor.java
+++ b/src/main/java/org/wickedsource/docxstamper/processor/repeat/RepeatDocPartProcessor.java
@@ -3,6 +3,7 @@ package org.wickedsource.docxstamper.processor.repeat;
 import org.docx4j.XmlUtils;
 import org.docx4j.jaxb.Context;
 import org.docx4j.openpackaging.packages.WordprocessingMLPackage;
+import org.docx4j.openpackaging.parts.WordprocessingML.CommentsPart;
 import org.docx4j.wml.*;
 import org.jvnet.jaxb2_commons.ppp.Child;
 import org.wickedsource.docxstamper.DocxStamper;
@@ -87,7 +88,7 @@ public class RepeatDocPartProcessor extends BaseCommentProcessor implements IRep
         subTemplates = new HashMap();
     }
 
-    private static WordprocessingMLPackage extractSubTemplate(CommentWrapper commentWrapper) {
+    private WordprocessingMLPackage extractSubTemplate(CommentWrapper commentWrapper) {
         CommentRangeStart start = commentWrapper.getCommentRangeStart();
 
         ContentAccessor gcp = findGreatestCommonParent(commentWrapper.getCommentRangeEnd(), (ContentAccessor) start.getParent());
@@ -98,7 +99,15 @@ public class RepeatDocPartProcessor extends BaseCommentProcessor implements IRep
 
         try {
             document = WordprocessingMLPackage.createPackage();
+            CommentsPart commentsPart = new CommentsPart();
+            document.getMainDocumentPart().addTargetPart(commentsPart);
+
             document.getMainDocumentPart().getContent().addAll(repeatElements);
+
+            Comments comments = objectFactory.createComments();
+            commentWrapper.getChildren().forEach(comment -> comments.getComment().add(comment.getComment()));
+            commentsPart.setContents(comments);
+
             document.save(new File("temp.docx"));
         } catch (Exception e) {
             System.out.println(e);

--- a/src/main/java/org/wickedsource/docxstamper/processor/repeat/RepeatDocPartProcessor.java
+++ b/src/main/java/org/wickedsource/docxstamper/processor/repeat/RepeatDocPartProcessor.java
@@ -125,11 +125,10 @@ public class RepeatDocPartProcessor extends BaseCommentProcessor implements IRep
                 startFound = true;
             }
             if (startFound) {
-                repeatElements.add(element);
-
                 if (depthElementSearch(commentWrapper.getCommentRangeEnd(), element)) {
                     break;
                 }
+                repeatElements.add(element);
             }
         }
         return repeatElements;

--- a/src/main/java/org/wickedsource/docxstamper/processor/repeat/RepeatDocPartProcessor.java
+++ b/src/main/java/org/wickedsource/docxstamper/processor/repeat/RepeatDocPartProcessor.java
@@ -58,23 +58,26 @@ public class RepeatDocPartProcessor extends BaseCommentProcessor implements IRep
     public void commitChanges(WordprocessingMLPackage document) {
         int count = 0;
 
+        List<Object> changes = new ArrayList<>();
+
         for (CommentWrapper commentWrapper : subContexts.keySet()) {
             List<Object> expressionContexts = subContexts.get(commentWrapper);
             WordprocessingMLPackage subTemplate = subTemplates.get(commentWrapper);
 
             for (Object subContext : expressionContexts) {
-                // TODO : generate sub doc and insert content back in the document
                 DocxStamper<Object> stamper = new DocxStamper<>(config);
                 ByteArrayOutputStream output = new ByteArrayOutputStream();
                 stamper.stamp(subTemplate, subContext, output);
                 try {
                     WordprocessingMLPackage subDocument = WordprocessingMLPackage.load(new ByteArrayInputStream(output.toByteArray()));
+                    changes.addAll(subDocument.getMainDocumentPart().getContent());
                     subDocument.save(new File("subdoc-" + count + ".docx"));
                 } catch (Exception e) {
                     System.out.println(e);
                 }
                 count++;
             }
+            // TODO : insert changes back in the document in the right place and remove comment
         }
     }
 

--- a/src/main/java/org/wickedsource/docxstamper/processor/repeat/RepeatDocPartProcessor.java
+++ b/src/main/java/org/wickedsource/docxstamper/processor/repeat/RepeatDocPartProcessor.java
@@ -155,8 +155,6 @@ public class RepeatDocPartProcessor extends BaseCommentProcessor implements IRep
     private static ContentAccessor findInsertableParent(ContentAccessor searchFrom) {
         if (searchFrom instanceof Tc) { // if it's Tc - need add new cell to row
             return searchFrom;
-        } else if (searchFrom instanceof P) {
-            return searchFrom;
         }
         return findInsertableParent((ContentAccessor) ((Child) searchFrom).getParent());
     }

--- a/src/main/java/org/wickedsource/docxstamper/util/CommentUtil.java
+++ b/src/main/java/org/wickedsource/docxstamper/util/CommentUtil.java
@@ -17,235 +17,237 @@ import org.wickedsource.docxstamper.util.walk.DocumentWalker;
 import java.math.BigInteger;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Stack;
 
 public class CommentUtil {
 
-	private static Logger logger = LoggerFactory.getLogger(CommentUtil.class);
+    private static Logger logger = LoggerFactory.getLogger(CommentUtil.class);
 
-	private CommentUtil() {
+    private CommentUtil() {
 
-	}
+    }
 
-	/**
-	 * Returns the comment the given DOCX4J run is commented with.
-	 * @param run the DOCX4J run whose comment to retrieve.
-	 * @param document the document that contains the run.
-	 * @return the comment, if found, null otherwise.
-	 */
-	public static Comments.Comment getCommentAround(R run,
-			WordprocessingMLPackage document) {
-		try {
-			if (run instanceof Child) {
-				Child child = (Child) run;
-				ContentAccessor parent = (ContentAccessor) child.getParent();
-				if (parent == null)
-					return null;
-				CommentRangeStart possibleComment = null;
-				boolean foundChild = false;
-				for (Object contentElement : parent.getContent()) {
+    /**
+     * Returns the comment the given DOCX4J run is commented with.
+     *
+     * @param run      the DOCX4J run whose comment to retrieve.
+     * @param document the document that contains the run.
+     * @return the comment, if found, null otherwise.
+     */
+    public static Comments.Comment getCommentAround(R run,
+                                                    WordprocessingMLPackage document) {
+        try {
+            if (run instanceof Child) {
+                Child child = (Child) run;
+                ContentAccessor parent = (ContentAccessor) child.getParent();
+                if (parent == null)
+                    return null;
+                CommentRangeStart possibleComment = null;
+                boolean foundChild = false;
+                for (Object contentElement : parent.getContent()) {
 
-					// so first we look for the start of the comment
-					if (XmlUtils.unwrap(contentElement) instanceof CommentRangeStart) {
-						possibleComment = (CommentRangeStart) contentElement;
-					}
-					// then we check if the child we are looking for is ours
-					else if (possibleComment != null && child.equals(contentElement)) {
-						foundChild = true;
-					}
-					// and then if we have an end of a comment we are good!
-					else if (possibleComment != null && foundChild && XmlUtils
-							.unwrap(contentElement) instanceof CommentRangeEnd) {
-						try {
-							BigInteger id = possibleComment.getId();
-							CommentsPart commentsPart = (CommentsPart) document.getParts()
-									.get(new PartName("/word/comments.xml"));
-							Comments comments = commentsPart.getContents();
-							for (Comments.Comment comment : comments.getComment()) {
-								if (comment.getId().equals(id)) {
-									return comment;
-								}
-							}
-						}
-						catch (InvalidFormatException e) {
-							logger.warn(String.format(
-									"Error while searching comment. Skipping run %s.",
-									run), e);
-						}
-					}
-					// else restart
-					else {
-						possibleComment = null;
-						foundChild = false;
-					}
-				}
-			}
-			return null;
-		}
-		catch (Docx4JException e) {
-			throw new DocxStamperException(
-					"error accessing the comments of the document!", e);
-		}
-	}
+                    // so first we look for the start of the comment
+                    if (XmlUtils.unwrap(contentElement) instanceof CommentRangeStart) {
+                        possibleComment = (CommentRangeStart) contentElement;
+                    }
+                    // then we check if the child we are looking for is ours
+                    else if (possibleComment != null && child.equals(contentElement)) {
+                        foundChild = true;
+                    }
+                    // and then if we have an end of a comment we are good!
+                    else if (possibleComment != null && foundChild && XmlUtils
+                            .unwrap(contentElement) instanceof CommentRangeEnd) {
+                        try {
+                            BigInteger id = possibleComment.getId();
+                            CommentsPart commentsPart = (CommentsPart) document.getParts()
+                                    .get(new PartName("/word/comments.xml"));
+                            Comments comments = commentsPart.getContents();
+                            for (Comments.Comment comment : comments.getComment()) {
+                                if (comment.getId().equals(id)) {
+                                    return comment;
+                                }
+                            }
+                        } catch (InvalidFormatException e) {
+                            logger.warn(String.format(
+                                    "Error while searching comment. Skipping run %s.",
+                                    run), e);
+                        }
+                    }
+                    // else restart
+                    else {
+                        possibleComment = null;
+                        foundChild = false;
+                    }
+                }
+            }
+            return null;
+        } catch (Docx4JException e) {
+            throw new DocxStamperException(
+                    "error accessing the comments of the document!", e);
+        }
+    }
 
-	/**
-	 * Returns the first comment found for the given docx object. Note that an object is
-	 * only considered commented if the comment STARTS within the object. Comments
-	 * spanning several objects are not supported by this method.
-	 *
-	 * @param object the object whose comment to load.
-	 * @param document the document in which the object is embedded (needed to load the
-	 * comment from the comments.xml part).
-	 * @return the concatenated string of all paragraphs of text within the comment or
-	 * null if the specified object is not commented.
-	 * @throws Docx4JException in case of a Docx4J processing error.
-	 */
-	public static Comments.Comment getCommentFor(ContentAccessor object,
-			WordprocessingMLPackage document) {
-		try {
-			for (Object contentObject : object.getContent()) {
-				if (contentObject instanceof CommentRangeStart) {
-					try {
-						BigInteger id = ((CommentRangeStart) contentObject).getId();
-						CommentsPart commentsPart = (CommentsPart) document.getParts()
-								.get(new PartName("/word/comments.xml"));
-						Comments comments = commentsPart.getContents();
-						for (Comments.Comment comment : comments.getComment()) {
-							if (comment.getId().equals(id)) {
-								return comment;
-							}
-						}
-					}
-					catch (InvalidFormatException e) {
-						logger.warn(String.format(
-								"Error while searching comment. Skipping object %s.",
-								object), e);
-					}
-				}
-			}
-			return null;
-		}
-		catch (Docx4JException e) {
-			throw new DocxStamperException(
-					"error accessing the comments of the document!", e);
-		}
-	}
+    /**
+     * Returns the first comment found for the given docx object. Note that an object is
+     * only considered commented if the comment STARTS within the object. Comments
+     * spanning several objects are not supported by this method.
+     *
+     * @param object   the object whose comment to load.
+     * @param document the document in which the object is embedded (needed to load the
+     *                 comment from the comments.xml part).
+     * @return the concatenated string of all paragraphs of text within the comment or
+     * null if the specified object is not commented.
+     * @throws Docx4JException in case of a Docx4J processing error.
+     */
+    public static Comments.Comment getCommentFor(ContentAccessor object,
+                                                 WordprocessingMLPackage document) {
+        try {
+            for (Object contentObject : object.getContent()) {
+                if (contentObject instanceof CommentRangeStart) {
+                    try {
+                        BigInteger id = ((CommentRangeStart) contentObject).getId();
+                        CommentsPart commentsPart = (CommentsPart) document.getParts()
+                                .get(new PartName("/word/comments.xml"));
+                        Comments comments = commentsPart.getContents();
+                        for (Comments.Comment comment : comments.getComment()) {
+                            if (comment.getId().equals(id)) {
+                                return comment;
+                            }
+                        }
+                    } catch (InvalidFormatException e) {
+                        logger.warn(String.format(
+                                "Error while searching comment. Skipping object %s.",
+                                object), e);
+                    }
+                }
+            }
+            return null;
+        } catch (Docx4JException e) {
+            throw new DocxStamperException(
+                    "error accessing the comments of the document!", e);
+        }
+    }
 
-	public static String getCommentStringFor(ContentAccessor object,
-			WordprocessingMLPackage document) throws Docx4JException {
-		Comments.Comment comment = getCommentFor(object, document);
-		return getCommentString(comment);
-	}
+    public static String getCommentStringFor(ContentAccessor object,
+                                             WordprocessingMLPackage document) throws Docx4JException {
+        Comments.Comment comment = getCommentFor(object, document);
+        return getCommentString(comment);
+    }
 
-	/**
-	 * Returns the string value of the specified comment object.
-	 */
-	public static String getCommentString(Comments.Comment comment) {
-		StringBuilder builder = new StringBuilder();
-		for (Object commentChildObject : comment.getContent()) {
-			if (commentChildObject instanceof P) {
-				builder.append(new ParagraphWrapper((P) commentChildObject).getText());
-			}
-		}
-		return builder.toString();
-	}
+    /**
+     * Returns the string value of the specified comment object.
+     */
+    public static String getCommentString(Comments.Comment comment) {
+        StringBuilder builder = new StringBuilder();
+        for (Object commentChildObject : comment.getContent()) {
+            if (commentChildObject instanceof P) {
+                builder.append(new ParagraphWrapper((P) commentChildObject).getText());
+            }
+        }
+        return builder.toString();
+    }
 
-	public static void deleteComment(CommentWrapper comment) {
-		if (comment.getCommentRangeEnd() != null) {
-			ContentAccessor commentRangeEndParent = (ContentAccessor) comment
-					.getCommentRangeEnd().getParent();
-			commentRangeEndParent.getContent().remove(comment.getCommentRangeEnd());
-			deleteCommentReference(commentRangeEndParent,
-					comment.getCommentRangeEnd().getId());
-		}
-		if (comment.getCommentRangeStart() != null) {
-			ContentAccessor commentRangeStartParent = (ContentAccessor) comment
-					.getCommentRangeStart().getParent();
-			commentRangeStartParent.getContent().remove(comment.getCommentRangeStart());
-			deleteCommentReference(commentRangeStartParent,
-					comment.getCommentRangeStart().getId());
-		}
-		// TODO: also delete comment from comments.xml
-	}
+    public static void deleteComment(CommentWrapper comment) {
+        if (comment.getCommentRangeEnd() != null) {
+            ContentAccessor commentRangeEndParent = (ContentAccessor) comment
+                    .getCommentRangeEnd().getParent();
+            commentRangeEndParent.getContent().remove(comment.getCommentRangeEnd());
+            deleteCommentReference(commentRangeEndParent,
+                    comment.getCommentRangeEnd().getId());
+        }
+        if (comment.getCommentRangeStart() != null) {
+            ContentAccessor commentRangeStartParent = (ContentAccessor) comment
+                    .getCommentRangeStart().getParent();
+            commentRangeStartParent.getContent().remove(comment.getCommentRangeStart());
+            deleteCommentReference(commentRangeStartParent,
+                    comment.getCommentRangeStart().getId());
+        }
+        // TODO: also delete comment from comments.xml
+    }
 
-	private static boolean deleteCommentReference(ContentAccessor parent,
-			BigInteger commentId) {
-		for (int i = 0; i < parent.getContent().size(); i++) {
-			Object contentObject = XmlUtils.unwrap(parent.getContent().get(i));
-			if (contentObject instanceof ContentAccessor) {
-				if (deleteCommentReference((ContentAccessor) contentObject, commentId)) {
-					return true;
-				}
-			}
-			if (contentObject instanceof R) {
-				for (Object runContentObject : ((R) contentObject).getContent()) {
-					Object unwrapped = XmlUtils.unwrap(runContentObject);
-					if (unwrapped instanceof R.CommentReference) {
-						BigInteger foundCommentId = ((R.CommentReference) unwrapped)
-								.getId();
-						if (foundCommentId.equals(commentId)) {
-							parent.getContent().remove(i);
-							return true;
-						}
-					}
-				}
-			}
-		}
-		return false;
-	}
+    private static boolean deleteCommentReference(ContentAccessor parent,
+                                                  BigInteger commentId) {
+        for (int i = 0; i < parent.getContent().size(); i++) {
+            Object contentObject = XmlUtils.unwrap(parent.getContent().get(i));
+            if (contentObject instanceof ContentAccessor) {
+                if (deleteCommentReference((ContentAccessor) contentObject, commentId)) {
+                    return true;
+                }
+            }
+            if (contentObject instanceof R) {
+                for (Object runContentObject : ((R) contentObject).getContent()) {
+                    Object unwrapped = XmlUtils.unwrap(runContentObject);
+                    if (unwrapped instanceof R.CommentReference) {
+                        BigInteger foundCommentId = ((R.CommentReference) unwrapped)
+                                .getId();
+                        if (foundCommentId.equals(commentId)) {
+                            parent.getContent().remove(i);
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        return false;
+    }
 
-	public static Map<BigInteger, CommentWrapper> getComments(
-			WordprocessingMLPackage document) {
-		Map<BigInteger, CommentWrapper> comments = new HashMap<>();
-		collectCommentRanges(comments, document);
-		collectComments(comments, document);
-		return comments;
-	}
+    public static Map<BigInteger, CommentWrapper> getComments(
+            WordprocessingMLPackage document) {
+        Map<BigInteger, CommentWrapper> comments = new HashMap<>();
+        collectCommentRanges(comments, document);
+        collectComments(comments, document);
+        return comments;
+    }
 
-	private static void collectCommentRanges(
-			final Map<BigInteger, CommentWrapper> comments,
-			WordprocessingMLPackage document) {
-		DocumentWalker documentWalker = new BaseDocumentWalker(
-				document.getMainDocumentPart()) {
-			@Override
-			protected void onCommentRangeStart(CommentRangeStart commentRangeStart) {
-				CommentWrapper commentWrapper = comments.get(commentRangeStart.getId());
-				if (commentWrapper == null) {
-					commentWrapper = new CommentWrapper();
-					comments.put(commentRangeStart.getId(), commentWrapper);
-				}
-				commentWrapper.setCommentRangeStart(commentRangeStart);
-			}
+    private static void collectCommentRanges(
+            final Map<BigInteger, CommentWrapper> comments,
+            WordprocessingMLPackage document) {
+        Stack<BigInteger> stack = new Stack<>();
+        DocumentWalker documentWalker = new BaseDocumentWalker(
+                document.getMainDocumentPart()) {
+            @Override
+            protected void onCommentRangeStart(CommentRangeStart commentRangeStart) {
+                CommentWrapper commentWrapper = comments.get(commentRangeStart.getId());
+                if (commentWrapper == null) {
+                    commentWrapper = new CommentWrapper();
+                    comments.put(commentRangeStart.getId(), commentWrapper);
+                    if (!stack.isEmpty())
+                        comments.get(stack.peek()).getChildren().add(commentWrapper);
+                }
+                commentWrapper.setCommentRangeStart(commentRangeStart);
+                stack.push(commentRangeStart.getId());
+            }
 
-			@Override
-			protected void onCommentRangeEnd(CommentRangeEnd commentRangeEnd) {
-				CommentWrapper commentWrapper = comments.get(commentRangeEnd.getId());
-				if (commentWrapper == null) {
-					commentWrapper = new CommentWrapper();
-					comments.put(commentRangeEnd.getId(), commentWrapper);
-				}
-				commentWrapper.setCommentRangeEnd(commentRangeEnd);
-			}
-		};
-		documentWalker.walk();
-	}
+            @Override
+            protected void onCommentRangeEnd(CommentRangeEnd commentRangeEnd) {
+                CommentWrapper commentWrapper = comments.get(commentRangeEnd.getId());
+                if (commentWrapper == null) {
+                    throw new RuntimeException("UNEXPECTED !");
+                }
+                commentWrapper.setCommentRangeEnd(commentRangeEnd);
+                if (!stack.isEmpty() && stack.peek().equals(commentRangeEnd.getId()))
+                    stack.pop();
+            }
+        };
+        documentWalker.walk();
+    }
 
-	private static void collectComments(final Map<BigInteger, CommentWrapper> comments,
-			WordprocessingMLPackage document) {
-		try {
-			CommentsPart commentsPart = (CommentsPart) document.getParts()
-					.get(new PartName("/word/comments.xml"));
-			if (commentsPart != null) {
-				for (Comments.Comment comment : commentsPart.getContents().getComment()) {
-					CommentWrapper commentWrapper = comments.get(comment.getId());
-					if (commentWrapper != null) {
-						commentWrapper.setComment(comment);
-					}
-				}
-			}
-		}
-		catch (Docx4JException e) {
-			throw new IllegalStateException(e);
-		}
-	}
+    private static void collectComments(final Map<BigInteger, CommentWrapper> comments,
+                                        WordprocessingMLPackage document) {
+        try {
+            CommentsPart commentsPart = (CommentsPart) document.getParts()
+                    .get(new PartName("/word/comments.xml"));
+            if (commentsPart != null) {
+                for (Comments.Comment comment : commentsPart.getContents().getComment()) {
+                    CommentWrapper commentWrapper = comments.get(comment.getId());
+                    if (commentWrapper != null) {
+                        commentWrapper.setComment(comment);
+                    }
+                }
+            }
+        } catch (Docx4JException e) {
+            throw new IllegalStateException(e);
+        }
+    }
 
 }

--- a/src/main/java/org/wickedsource/docxstamper/util/CommentWrapper.java
+++ b/src/main/java/org/wickedsource/docxstamper/util/CommentWrapper.java
@@ -4,6 +4,9 @@ import org.docx4j.wml.CommentRangeEnd;
 import org.docx4j.wml.CommentRangeStart;
 import org.docx4j.wml.Comments;
 
+import java.util.HashSet;
+import java.util.Set;
+
 public class CommentWrapper {
 
     private Comments.Comment comment;
@@ -11,6 +14,8 @@ public class CommentWrapper {
     private CommentRangeStart commentRangeStart;
 
     private CommentRangeEnd commentRangeEnd;
+
+    private Set<CommentWrapper> children = new HashSet();
 
     public CommentWrapper(Comments.Comment comment, CommentRangeStart commentRangeStart, CommentRangeEnd commentRangeEnd) {
         this.comment = comment;
@@ -33,6 +38,10 @@ public class CommentWrapper {
         return commentRangeEnd;
     }
 
+    public Set<CommentWrapper> getChildren() {
+        return children;
+    }
+
     void setComment(Comments.Comment comment) {
         this.comment = comment;
     }
@@ -43,5 +52,9 @@ public class CommentWrapper {
 
     void setCommentRangeEnd(CommentRangeEnd commentRangeEnd) {
         this.commentRangeEnd = commentRangeEnd;
+    }
+
+    void setChildren(Set<CommentWrapper> children) {
+        this.children = children;
     }
 }


### PR DESCRIPTION
When a repeatDocPart comment range end is bound to a placeholder, it was excluded from the repeatable doc part and left as is in the stamped document. 