### PR TITLE
Feature/docx4j 11.4.x compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,17 +128,17 @@ To include docx-stamper in your project, you can use the following maven coordin
 <dependency>
     <groupId>org.wickedsource.docx-stamper</groupId>
     <artifactId>docx-stamper</artifactId>
-    <version>1.4.0</version>
+    <version>1.5.0</version>
 </dependency>
 ```
 
-Note that as of version 1.4.0 you have to provide the dependency to your version of Docx4J yourself:
+Note that as of version 1.5.0 you have to provide the dependency to your version of Docx4J yourself:
 
 ```xml
 <dependency>
     <groupId>org.docx4j</groupId>
-    <artifactId>docx4j</artifactId>
-    <version>6.1.2</version>
+    <artifactId>docx4j-JAXB-ReferenceImpl</artifactId>
+    <version>11.4.9</version>
 </dependency>
 ```
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 plugins {
     id "java"
     id "java-library"
-    id "com.jfrog.artifactory" version "4.5.4"
-    id "com.jfrog.bintray" version "1.8.1"
+    id "com.jfrog.artifactory" version "4.31.7"
+    id "com.jfrog.bintray" version "1.8.5"
     id "maven-publish"
 }
 
@@ -13,26 +13,26 @@ repositories {
 }
 
 // run gradle with "-Dsnapshot=true" to automatically append "-SNAPSHOT" to the version
-version = '1.4.0' + (Boolean.valueOf(System.getProperty("snapshot")) ? "-SNAPSHOT" : "")
-sourceCompatibility = 1.8
+version = '1.5.0' + (Boolean.valueOf(System.getProperty("snapshot")) ? "-SNAPSHOT" : "")
+sourceCompatibility = 11
 
 ext{
     bintrayUser = System.getProperty("bintray.user")
     bintrayKey = System.getProperty("bintray.key")
     buildNumber = System.getProperty("build.number")
-    docx4JVersion = System.getProperty("docx4j.version") ? System.getProperty("docx4j.version") : '6.1.2'
+    docx4JVersion = System.getProperty("docx4j.version") ? System.getProperty("docx4j.version") : '11.4.9'
 }
 
 dependencies {
-    implementation("commons-io:commons-io:2.5")
-    implementation("org.javassist:javassist:3.21.0-GA")
-    implementation("org.springframework:spring-expression:4.3.6.RELEASE")
+    implementation("commons-io:commons-io:2.11.0")
+    implementation("org.javassist:javassist:3.29.2-GA")
+    implementation("org.springframework:spring-expression:5.3.26")
 
     // We want docx-stamper to be usable with any docx4j version, so the dependency to docx4J
     // has to be provided by the client.
-    compileOnly("org.docx4j:docx4j:${docx4JVersion}")
+    compileOnly("org.docx4j:docx4j-JAXB-ReferenceImpl:${docx4JVersion}")
     
-    testImplementation("org.docx4j:docx4j:${docx4JVersion}")    
+    testImplementation("org.docx4j:docx4j-JAXB-ReferenceImpl:${docx4JVersion}")
     testImplementation("junit:junit:4.4")
 }
 
@@ -98,7 +98,7 @@ publishing {
 }
 
 artifactory {
-    contextUrl = 'http://oss.jfrog.org'
+    contextUrl = 'https://oss.jfrog.org'
     publish {
         repository {
             repoKey = 'oss-snapshot-local'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.6.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip

--- a/src/main/java/org/wickedsource/docxstamper/util/RunUtil.java
+++ b/src/main/java/org/wickedsource/docxstamper/util/RunUtil.java
@@ -4,7 +4,7 @@ import org.docx4j.jaxb.Context;
 import org.docx4j.model.styles.StyleUtil;
 import org.docx4j.wml.*;
 
-import javax.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBElement;
 
 public class RunUtil {
 

--- a/src/main/java/org/wickedsource/docxstamper/util/TableCellUtil.java
+++ b/src/main/java/org/wickedsource/docxstamper/util/TableCellUtil.java
@@ -5,7 +5,7 @@ import org.docx4j.wml.P;
 import org.docx4j.wml.Tbl;
 import org.docx4j.wml.Tc;
 
-import javax.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBElement;
 
 
 public class TableCellUtil {

--- a/src/main/java/org/wickedsource/docxstamper/util/walk/CoordinatesWalker.java
+++ b/src/main/java/org/wickedsource/docxstamper/util/walk/CoordinatesWalker.java
@@ -10,7 +10,7 @@ import org.docx4j.relationships.Relationship;
 import org.docx4j.wml.*;
 import org.wickedsource.docxstamper.api.coordinates.*;
 
-import javax.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBElement;
 import java.util.ArrayList;
 import java.util.List;
 

--- a/src/main/java/org/wickedsource/docxstamper/util/walk/DocumentWalker.java
+++ b/src/main/java/org/wickedsource/docxstamper/util/walk/DocumentWalker.java
@@ -3,7 +3,7 @@ package org.wickedsource.docxstamper.util.walk;
 import org.docx4j.XmlUtils;
 import org.docx4j.wml.*;
 
-import javax.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBElement;
 
 public abstract class DocumentWalker {
 

--- a/src/test/java/org/wickedsource/docxstamper/ConditionalDisplayOfParagraphsTest.java
+++ b/src/test/java/org/wickedsource/docxstamper/ConditionalDisplayOfParagraphsTest.java
@@ -14,7 +14,7 @@ import org.wickedsource.docxstamper.util.ParagraphWrapper;
 import org.wickedsource.docxstamper.util.walk.BaseCoordinatesWalker;
 import org.wickedsource.docxstamper.util.walk.CoordinatesWalker;
 
-import javax.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBElement;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;

--- a/src/test/java/org/wickedsource/docxstamper/ConditionalDisplayOfTablesTest.java
+++ b/src/test/java/org/wickedsource/docxstamper/ConditionalDisplayOfTablesTest.java
@@ -11,7 +11,7 @@ import org.junit.Test;
 import org.wickedsource.docxstamper.context.NameContext;
 import org.wickedsource.docxstamper.util.ParagraphWrapper;
 
-import javax.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBElement;
 import java.io.IOException;
 import java.io.InputStream;
 

--- a/src/test/java/org/wickedsource/docxstamper/ExpressionReplacementInTablesTest.java
+++ b/src/test/java/org/wickedsource/docxstamper/ExpressionReplacementInTablesTest.java
@@ -11,7 +11,7 @@ import org.junit.Test;
 import org.wickedsource.docxstamper.context.NameContext;
 import org.wickedsource.docxstamper.util.ParagraphWrapper;
 
-import javax.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBElement;
 import java.io.IOException;
 import java.io.InputStream;
 

--- a/src/test/java/org/wickedsource/docxstamper/ImageReplacementInGlobalParagraphsTest.java
+++ b/src/test/java/org/wickedsource/docxstamper/ImageReplacementInGlobalParagraphsTest.java
@@ -10,7 +10,7 @@ import org.junit.Test;
 import org.wickedsource.docxstamper.context.ImageContext;
 import org.wickedsource.docxstamper.replace.typeresolver.image.Image;
 
-import javax.xml.bind.JAXBElement;
+import jakarta.xml.bind.JAXBElement;
 import java.io.IOException;
 import java.io.InputStream;
 


### PR DESCRIPTION
Update to make docx-stamper compatible with latest docx4j 11.4.x which uses jakarta namespace

